### PR TITLE
Copiar el estilo de párrafo al de fuente, si este no ha sido configurado

### DIFF
--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -100,6 +100,10 @@ abstract class AbstractContainer extends AbstractElement
             // @todo Remove the `$count` parameter in 1.0.0 to make this element similiar to other elements?
             if ($element == 'TextBreak') {
                 list($count, $fontStyle, $paragraphStyle) = array_pad($args, 3, null);
+
+                // If the length of $fontStyle is 0, copy the value of $paragraphStyle to $fontStyle
+                $fontStyle = (is_array($fontStyle) && count($fontStyle) == 0) ? $paragraphStyle : $fontStyle;
+
                 if ($count === null) {
                     $count = 1;
                 }


### PR DESCRIPTION
# Asegurarse que el estilo de fuente sea aplicado

Cuando se genera un textbreak, PHPWord no considera el estilo de fuente especificado.

## Cambios realizados

- Se agregó una verificación para determinar si `$fontStyle` no se encuentra configurado y si no, se copia el valor de `$paragraphStyle`, que es equivalente.

